### PR TITLE
Specify the config directory and file permissions

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,8 +25,17 @@ ark "duosecurity" do
 end
 
 # Config
+directory "/etc/duo" do
+  mode "0755"
+  owner "root"
+  group "root"
+end
+
 # https://www.duosecurity.com/docs/duounix#configuration-options
 template "/etc/duo/login_duo.conf" do
+  mode "0400"
+  owner "root"
+  group "root"
   source "login_duo.conf.erb"
   sensitive true
   variables(


### PR DESCRIPTION
The `ark` install may create `/etc/duo` and touch `/etc/duo/login_duo.conf` with the correct permissions but it's always nice to be explicit and important when using a wrapper cookbook.