### PR TITLE
Allow install from package

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,4 @@
+default['duosecurity']['install_type'] = 'source'
+default['duosecurity']['package_action'] = 'upgrade'
+default['duosecurity']['source_sha256'] = '415cf02981f66ba9447df81e2fcf41e004220126640cc5f667720d46c431abf9'
+default['duosecurity']['source_version'] = '1.9.14'

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,9 +6,10 @@ description         "Installs/Configures duosecurity"
 long_description    IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version             "1.0.2"
 
+supports            "debian"
 supports            "ubuntu"
-provides            "duosecurity::default"
 recipe              "duosecurity::default", "Installs and configures login_duo"
+recipe              "duosecurity::package", "Installs login_duo from package"
+recipe              "duosecurity::source", "Installs login_duo from source"
 depends             "ark"
 source_url          "https://github.com/articulate/chef-duosecurity"
-

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -15,14 +15,7 @@ accept_env_factor   = node["duosecurity"]["accept_env_factor"] if node["duosecur
 fallback_local_ip   = node["duosecurity"]["fallback_local_ip"] if node["duosecurity"]["fallback_local_ip"]
 https_timeout       = node["duosecurity"]["https_timeout"] if node["duosecurity"]["https_timeout"]
 
-# Install login_duo
-# https://www.duosecurity.com/docs/duounix#1.-set-up-login_duo
-ark "duosecurity" do
-  url "https://dl.duosecurity.com/duo_unix-latest.tar.gz"
-  autoconf_opts ["--prefix=/usr"]
-  checksum "415cf02981f66ba9447df81e2fcf41e004220126640cc5f667720d46c431abf9"
-  action :install_with_make
-end
+include_recipe "duosecurity::#{node['duosecurity']['install_type']}"
 
 # Config
 directory "/etc/duo" do

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -1,0 +1,3 @@
+package 'login-duo' do
+  action node['duosecurity']['package_action'].to_sym
+end

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -1,0 +1,8 @@
+# Install login_duo
+# https://www.duosecurity.com/docs/duounix#1.-set-up-login_duo
+ark "duosecurity" do
+  url "https://dl.duosecurity.com/duo_unix-#{node['duosecurity']['source_version']}.tar.gz"
+  autoconf_opts ["--prefix=/usr"]
+  checksum node['duosecurity']['source_sha256']
+  action :install_with_make
+end


### PR DESCRIPTION
Allows you to install the [Ubuntu](http://packages.ubuntu.com/search?keywords=login-duo&searchon=names) or [Debian](https://tracker.debian.org/pkg/duo-unix) packages if desired but continues to default to source for most up to date version.