### PR TITLE
Ignore source_url in metadata for Chef 11

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -12,4 +12,4 @@ recipe              "duosecurity::default", "Installs and configures login_duo"
 recipe              "duosecurity::package", "Installs login_duo from package"
 recipe              "duosecurity::source", "Installs login_duo from source"
 depends             "ark"
-source_url          "https://github.com/articulate/chef-duosecurity"
+source_url          "https://github.com/articulate/chef-duosecurity" if respond_to?(:source_url)


### PR DESCRIPTION
Amazon AWS doesn't support Chef 12 on Linux yet so this attribute has to be ignored or else Chef will bail out. This gives compatibility to older Chef versions.