### PR TITLE
update .kitchen.yml file to use chef-12.6.0 vagrant base box

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,10 +8,10 @@ provisioner:
   chef_omnibus_url: https://s3.amazonaws.com/articulate-chef/custom_chef_install.sh
 
 platforms:
-  - name: ubuntu-12.04
+  - name: ubuntu
     driver_config:
-      box: opscode-ubuntu-12.04
-      box_url: http://d1m352yddr2wlq.cloudfront.net/articulate-opscode-12.04.box
+      box: ubuntu-12.04.5-chef-12.6.0
+      box_url: http://d30mo6j6uouwb9.cloudfront.net/vagrant-boxes/ubuntu-12.04.5-chef-12.6.0-virtualbox.box
 
       network:
       - ["private_network", {ip: "192.168.33.20"}]


### PR DESCRIPTION
result from `kitchen converge source-ubuntu` run:

```
Running handlers:
       Running handlers complete

       Deprecated features used!
         Using an LWRP provider by its name (Ark) directly is no longer supported in Chef 12 and will be removed.  Use Chef::ProviderResolver.new(node, resource, action) instead. at 1 location:
           - /tmp/kitchen/cookbooks/ark/resources/default.rb:26:in `initialize'

       Chef Client finished, 13/27 resources updated in 12 seconds
       Finished converging <source-ubuntu> (0m18.98s).
-----> Kitchen is finished. (1m0.98s)
```